### PR TITLE
[FIX] Fix Psycopg2-binary library for Postgress

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ packaging==21.0
 passlib==1.7.4
 pluggy==0.13.1
 prompt-toolkit==3.0.20
-# psycopg2==2.9.1
+psycopg2-binary==2.9.3
 py==1.10.0
 pyasn1==0.4.8
 pycparser==2.20


### PR DESCRIPTION
- Fix adding `psycopg2-binary@2.9.3` to `requirements.txt`.